### PR TITLE
Add support for username and password in ActiveMQ connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,12 @@ You may use any standard Logback encoder, but if you are sending your messages t
 
 ## Configuration
 
-| Property Name      | Example                                                                                                      | Purpose                                                                             |
-|--------------------|--------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
-| brokerUrl          | failover:(ssl://activemq-1.example.com:61616,ssl://activemq-2.example.com:61616)?randomize=false&backup=true | The ActiveMQ client URL. Any valid ActiveMQ client URL can be used.                 |
-| queueName          | ch.qos.logback                                                                                               | The Queue name to write logs to                                                 |
-
+| Property Name      | Optional? | Example                                                                                                      | Purpose                                                                             |
+|--------------------|-----------|--------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
+| brokerUrl          | No        | failover:(ssl://activemq-1.example.com:61616,ssl://activemq-2.example.com:61616)?randomize=false&backup=true | The ActiveMQ client URL. Any valid ActiveMQ client URL can be used.                 |
+| username           | Yes       | loguser                                                                                                      | The username to use to establish the connection to ActiveMQ                         |
+| password           | Yes       | ${PASSWORD_FROM_ENVIRONMENT_VARIABLE}                                                                        | The password to use to establish the connection to ActiveMQ                         |
+| queueName          | No        | ch.qos.logback                                                                                               | The Queue name to write logs to                                                     |
 
 ### Example logback.xml
 
@@ -53,6 +54,8 @@ Here's a working `logback.xml` that includes the previously mentioned GELF encod
 		name="gelf-jms"
 		class="com.github.exabrial.logback.ActiveMQAppender">
 		<brokerUrl>failover:(ssl://activemq-1.example.com:61616,ssl://activemq-2.example.com:61616)?randomize=false&amp;backup=true</brokerUrl>
+        <username>loguser</username>
+        <password>${PASSWORD_FROM_ENVIRONMENT_VARIABLE}</password>
 		<encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
 			<layout class="me.moocar.logbackgelf.GelfLayout">
 				<useLoggerName>true</useLoggerName>

--- a/src/main/java/com/github/exabrial/logback/ActiveMQAppender.java
+++ b/src/main/java/com/github/exabrial/logback/ActiveMQAppender.java
@@ -5,6 +5,8 @@ import ch.qos.logback.core.OutputStreamAppender;
 public class ActiveMQAppender<E> extends OutputStreamAppender<E> {
 	private String brokerUrl = null;
 	private String queueName = "ch.qos.logback";
+	private String username = null;
+	private String password = null;
 
 	@Override
 	public void start() {
@@ -12,7 +14,7 @@ public class ActiveMQAppender<E> extends OutputStreamAppender<E> {
 			return;
 		} else {
 			try {
-				setOutputStream(new ActiveMQTextMessageOutputStream(brokerUrl, queueName));
+				setOutputStream(new ActiveMQTextMessageOutputStream(brokerUrl, username, password, queueName));
 				super.start();
 			} catch (Exception e) {
 				addError("start() caught exception!", e);
@@ -34,6 +36,22 @@ public class ActiveMQAppender<E> extends OutputStreamAppender<E> {
 
 	public void setQueueName(String queueName) {
 		this.queueName = queueName;
+	}
+
+	public String getUsername() {
+		return username;
+	}
+
+	public void setUsername(String username) {
+		this.username = username;
+	}
+
+	public String getPassword() {
+		return password;
+	}
+
+	public void setPassword(String password) {
+		this.password = password;
 	}
 
 	@Override

--- a/src/main/java/com/github/exabrial/logback/ActiveMQTextMessageOutputStream.java
+++ b/src/main/java/com/github/exabrial/logback/ActiveMQTextMessageOutputStream.java
@@ -17,6 +17,8 @@ import org.apache.activemq.ActiveMQConnectionFactory;
 
 public class ActiveMQTextMessageOutputStream extends OutputStream {
 	private final String brokerUrl;
+	private String username;
+	private String password;
 	private final String queueName;
 	private String state = "uninitialized";
 	private Writer writer;
@@ -25,11 +27,18 @@ public class ActiveMQTextMessageOutputStream extends OutputStream {
 	private MessageProducer producer;
 	private Session session;
 
-	public ActiveMQTextMessageOutputStream(String brokerUrl, String queueName) {
+	public ActiveMQTextMessageOutputStream(String brokerUrl, String username, String password, String queueName) {
 		this.brokerUrl = brokerUrl;
+		this.username = username;
+		this.password = password;
 		this.queueName = queueName;
 		try {
-			ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(brokerUrl);
+			ActiveMQConnectionFactory connectionFactory;
+			if (username != null && !"".equals(username)) {
+				connectionFactory = new ActiveMQConnectionFactory(username, password, brokerUrl);
+			} else {
+				connectionFactory = new ActiveMQConnectionFactory(brokerUrl);
+			}
 			connection = connectionFactory.createConnection();
 			connection.start();
 			connection.setExceptionListener(new ExceptionListener() {


### PR DESCRIPTION
This adds the possibility the specify username and password for the ActiveMQ connection in the logback configuration.